### PR TITLE
Fix raw strings

### DIFF
--- a/multiavatar/multiavatar.py
+++ b/multiavatar/multiavatar.py
@@ -20,7 +20,7 @@ def multiavatar (string, sansEnv, ver):
         svgString = sP[partV][part]
         # print(colors, svgString)
 
-        regex = "\#(.*?)\;"
+        regex = r"\#(.*?)\;"
         result = re.findall(regex, svgString)
         # print(result)
 
@@ -660,7 +660,7 @@ def multiavatar (string, sansEnv, ver):
     sha256Hash = sha256(string.encode('utf-8')).hexdigest()
 
     import re
-    sha256Numbers = re.sub('\D', '', sha256Hash)
+    sha256Numbers = re.sub(r'\D', '', sha256Hash)
 
     hash = sha256Numbers[0:12]
     


### PR DESCRIPTION
When I run my script with debugger tools connected, I got Syntax error as soon as multiavatar import is there:

```
>   from multiavatar.multiavatar import multiavatar
E     File "/my/home/.pyenv/versions/my-project/lib/python3.12/site-packages/multiavatar/multiavatar.py", line 23
E       regex = "\#(.*?)\;"
E               ^^^^^^^^^^^
E   SyntaxError: invalid escape sequence '\#'
```

The proper syntax for the regex strings defined should be r-prefixed